### PR TITLE
Update description for ubuntu templates to include micro version

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -17,7 +17,7 @@ templates:
     cpu: 2
     deprecated: false
     deprecated_in_cse_version: ""
-    description: "Ubuntu 16.04, Docker-ce 18.09.7, Kubernetes 1.13.5, weave 2.3.0"
+    description: "Ubuntu 16.04.6, Docker-ce 18.09.7, Kubernetes 1.13.5, weave 2.3.0"
     mem: 2048
     name: ubuntu-16.04_k8-1.13_weave-2.3.0
     required_cse_version: "2.5.0"
@@ -30,7 +30,7 @@ templates:
     cpu: 2
     deprecated: false
     deprecated_in_cse_version: ""
-    description: "Ubuntu 16.04, Docker-ce 18.09.7, Kubernetes 1.15.3, weave 2.5.2"
+    description: "Ubuntu 16.04.6, Docker-ce 18.09.7, Kubernetes 1.15.3, weave 2.5.2"
     mem: 2048
     name: ubuntu-16.04_k8-1.15_weave-2.5.2
     required_cse_version: "2.5.0"


### PR DESCRIPTION
Checked using `lsb_release -a` to verify our ubuntu version:

```
root@mstr-7pj3:~# lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 16.04.6 LTS
Release:        16.04
Codename:       xenial
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension-templates/5)
<!-- Reviewable:end -->
