### PR TITLE
[VCDA-1881] Ubuntu 1.19 template

### DIFF
--- a/scripts/ubuntu-16.04_k8-1.19_weave-2.6.5_rev1/cluster-upgrade/docker-upgrade.sh
+++ b/scripts/ubuntu-16.04_k8-1.19_weave-2.6.5_rev1/cluster-upgrade/docker-upgrade.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo 'upgrading packages to: docker-ce=5:19.03.12~3-0~ubuntu-xenial'
+apt-get -q update -o Acquire::Retries=3 -o Acquire::http::No-Cache=True -o Acquire::http::Timeout=30 -o Acquire::https::No-Cache=True -o Acquire::https::Timeout=30 -o Acquire::ftp::Timeout=30
+apt-get install -y --allow-change-held-packages docker-ce=5:19.03.12~3-0~ubuntu-xenial
+systemctl restart docker
+while [ `systemctl is-active docker` != 'active' ]; do echo 'waiting for docker'; sleep 5; done

--- a/scripts/ubuntu-16.04_k8-1.19_weave-2.6.5_rev1/cluster-upgrade/master-cni-apply.sh
+++ b/scripts/ubuntu-16.04_k8-1.19_weave-2.6.5_rev1/cluster-upgrade/master-cni-apply.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+export kubever=$(kubectl version --client | base64 | tr -d '\n')
+wget --no-verbose -O /root/weave.yml "https://cloud.weave.works/k8s/net?k8s-version=$kubever&v=2.6.5"
+kubectl apply -f /root/weave.yml
+systemctl restart kubelet
+while [ `systemctl is-active kubelet` != 'active' ]; do echo 'waiting for kubelet'; sleep 5; done

--- a/scripts/ubuntu-16.04_k8-1.19_weave-2.6.5_rev1/cluster-upgrade/master-k8s-upgrade.sh
+++ b/scripts/ubuntu-16.04_k8-1.19_weave-2.6.5_rev1/cluster-upgrade/master-k8s-upgrade.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo 'upgrading packages to: kubeadm=1.19.3-00'
+apt-get -q update -o Acquire::Retries=3 -o Acquire::http::No-Cache=True -o Acquire::http::Timeout=30 -o Acquire::https::No-Cache=True -o Acquire::https::Timeout=30 -o Acquire::ftp::Timeout=30
+apt-get install -y --allow-change-held-packages kubeadm=1.19.3-00 kubernetes-cni=0.8.7-00
+
+echo 'upgrading kubeadm to v1.19.3'
+while [ `systemctl is-active kubelet` != 'active' ]; do echo 'waiting for kubelet'; sleep 5; done
+# sometimes master will be in 'NotReady' state for a short period
+# api server needs to answer 'OK' to `/healthz`
+# https://github.com/kubernetes/kubeadm/issues/539
+# upgrade needs to go through various checks
+# master readiness check is not sufficient: while [ `kubectl get nodes | awk '/master/ {print $2}'` != 'Ready,SchedulingDisabled' ]; do echo 'waiting for master to be ready'; sleep 5; done
+sleep 120
+kubeadm upgrade apply v1.19.3 -y
+
+echo 'upgrading packages to: kubelet=1.19.3-00 kubectl=1.19.3-00 kubernetes-cni=0.8.7-00'
+apt-get -q update -o Acquire::Retries=3 -o Acquire::http::No-Cache=True -o Acquire::http::Timeout=30 -o Acquire::https::No-Cache=True -o Acquire::https::Timeout=30 -o Acquire::ftp::Timeout=30
+apt-get install -y --allow-change-held-packages kubelet=1.19.3-00 kubectl=1.19.3-00 kubernetes-cni=0.8.7-00 --allow-unauthenticated
+
+systemctl restart kubelet
+while [ `systemctl is-active kubelet` != 'active' ]; do echo 'waiting for kubelet'; sleep 5; done

--- a/scripts/ubuntu-16.04_k8-1.19_weave-2.6.5_rev1/cluster-upgrade/worker-k8s-upgrade.sh
+++ b/scripts/ubuntu-16.04_k8-1.19_weave-2.6.5_rev1/cluster-upgrade/worker-k8s-upgrade.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo 'upgrading packages to: kubeadm=1.19.3-00'
+apt-get -q update -o Acquire::Retries=3 -o Acquire::http::No-Cache=True -o Acquire::http::Timeout=30 -o Acquire::https::No-Cache=True -o Acquire::https::Timeout=30 -o Acquire::ftp::Timeout=30
+apt-get install -y --allow-change-held-packages kubeadm=1.19.3-00 kubernetes-cni=0.8.7-00
+echo 'upgrading kubeadm in worker node'
+kubeadm upgrade node
+
+echo 'upgrading packages to: kubelet=1.19.3-00 kubectl=1.19.3-00 kubernetes-cni=0.8.7-00'
+apt-get -q update -o Acquire::Retries=3 -o Acquire::http::No-Cache=True -o Acquire::http::Timeout=30 -o Acquire::https::No-Cache=True -o Acquire::https::Timeout=30 -o Acquire::ftp::Timeout=30
+apt-get install -y --allow-change-held-packages kubelet=1.19.3-00 kubectl=1.19.3-00 kubernetes-cni=0.8.7-00
+systemctl restart kubelet
+while [ `systemctl is-active kubelet` != 'active' ]; do echo 'waiting for kubelet'; sleep 5; done

--- a/scripts/ubuntu-16.04_k8-1.19_weave-2.6.5_rev1/cust.sh
+++ b/scripts/ubuntu-16.04_k8-1.19_weave-2.6.5_rev1/cust.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -e
+
+# disable ipv6 to avoid possible connection errors
+echo 'net.ipv6.conf.all.disable_ipv6 = 1' >> /etc/sysctl.conf
+echo 'net.ipv6.conf.default.disable_ipv6 = 1' >> /etc/sysctl.conf
+echo 'net.ipv6.conf.lo.disable_ipv6 = 1' >> /etc/sysctl.conf
+sudo sysctl -p
+
+echo 'nameserver 8.8.8.8' >> /etc/resolvconf/resolv.conf.d/tail
+resolvconf -u
+
+systemctl restart networking.service
+while [ `systemctl is-active networking` != 'active' ]; do echo 'waiting for network'; sleep 5; done
+
+growpart /dev/sda 1 || :
+resize2fs /dev/sda1 || :
+
+# redundancy: https://github.com/vmware/container-service-extension/issues/432
+systemctl restart networking.service
+while [ `systemctl is-active networking` != 'active' ]; do echo 'waiting for network'; sleep 5; done
+
+echo 'installing kubernetes'
+export DEBIAN_FRONTEND=noninteractive
+apt-get -q update -o Acquire::Retries=3 -o Acquire::http::No-Cache=True -o Acquire::http::Timeout=30 -o Acquire::https::No-Cache=True -o Acquire::https::Timeout=30 -o Acquire::ftp::Timeout=30
+apt-get -q install -y apt-transport-https ca-certificates curl software-properties-common
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
+deb http://apt.kubernetes.io/ kubernetes-xenial main
+EOF
+add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+apt-get -q update -o Acquire::Retries=3 -o Acquire::http::No-Cache=True -o Acquire::http::Timeout=30 -o Acquire::https::No-Cache=True -o Acquire::https::Timeout=30 -o Acquire::ftp::Timeout=30
+apt-get -q install -y docker-ce=5:19.03.12~3-0~ubuntu-xenial
+apt-get -q install -y kubelet=1.19.3-00 kubeadm=1.19.3-00 kubectl=1.19.3-00 kubernetes-cni=0.8.7-00
+systemctl restart docker
+while [ `systemctl is-active docker` != 'active' ]; do echo 'waiting for docker'; sleep 5; done
+
+echo 'installing required software for NFS'
+apt-get -q install -y nfs-common nfs-kernel-server
+systemctl stop nfs-kernel-server.service
+systemctl disable nfs-kernel-server.service
+
+# prevent updates to software that CSE depends on
+apt-mark hold open-vm-tools
+apt-mark hold docker-ce
+apt-mark hold kubelet
+apt-mark hold kubeadm
+apt-mark hold kubectl
+apt-mark hold kubernetes-cni
+apt-mark hold nfs-common
+apt-mark hold nfs-kernel-server
+
+echo 'upgrading the system'
+apt-get -q update -o Acquire::Retries=3 -o Acquire::http::No-Cache=True -o Acquire::http::Timeout=30 -o Acquire::https::No-Cache=True -o Acquire::https::Timeout=30 -o Acquire::ftp::Timeout=30
+apt-get -y -q -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade
+
+# /etc/machine-id must be empty so that new machine-id gets assigned on boot (in our case boot is vApp deployment)
+# https://jaylacroix.com/fixing-ubuntu-18-04-virtual-machines-that-fight-over-the-same-ip-address/
+truncate -s 0 /etc/machine-id
+rm /var/lib/dbus/machine-id || :
+ln -fs /etc/machine-id /var/lib/dbus/machine-id || : # dbus/machine-id is symlink pointing to /etc/machine-id
+
+sync
+sync
+echo 'customization completed'

--- a/scripts/ubuntu-16.04_k8-1.19_weave-2.6.5_rev1/init.sh
+++ b/scripts/ubuntu-16.04_k8-1.19_weave-2.6.5_rev1/init.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+sed -i -e 's/^PasswordAuthentication yes/PasswordAuthentication no/' -e 's/^PermitRootLogin yes/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config
+
+apt remove -y cloud-init
+dpkg-reconfigure openssh-server
+sync
+sync

--- a/scripts/ubuntu-16.04_k8-1.19_weave-2.6.5_rev1/mstr.sh
+++ b/scripts/ubuntu-16.04_k8-1.19_weave-2.6.5_rev1/mstr.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+while [ `systemctl is-active docker` != 'active' ]; do echo 'waiting for docker'; sleep 5; done
+kubeadm init --kubernetes-version=v1.19.3 > /root/kubeadm-init.out
+mkdir -p /root/.kube
+cp -f /etc/kubernetes/admin.conf /root/.kube/config
+chown $(id -u):$(id -g) /root/.kube/config
+
+export kubever=$(kubectl version --client | base64 | tr -d '\n')
+wget --no-verbose -O /root/weave.yml "https://cloud.weave.works/k8s/net?k8s-version=$kubever&v=2.6.5"
+kubectl apply -f /root/weave.yml
+systemctl restart kubelet
+while [ `systemctl is-active kubelet` != 'active' ]; do echo 'waiting for kubelet'; sleep 5; done

--- a/scripts/ubuntu-16.04_k8-1.19_weave-2.6.5_rev1/nfsd.sh
+++ b/scripts/ubuntu-16.04_k8-1.19_weave-2.6.5_rev1/nfsd.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+
+systemctl enable nfs-kernel-server.service
+systemctl start nfs-kernel-server.service
+echo '/home *(rw,sync,no_root_squash,no_subtree_check)' >> /etc/exports
+systemctl restart nfs-kernel-server.service

--- a/scripts/ubuntu-16.04_k8-1.19_weave-2.6.5_rev1/node.sh
+++ b/scripts/ubuntu-16.04_k8-1.19_weave-2.6.5_rev1/node.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+while [ `systemctl is-active docker` != 'active' ]; do echo 'waiting for docker'; sleep 5; done
+kubeadm join --token {token} {ip}:6443 --discovery-token-unsafe-skip-ca-verification

--- a/template.yaml
+++ b/template.yaml
@@ -2,6 +2,26 @@ templates:
   - compute_policy: ""
     cpu: 2
     deprecated: false
+    description: "Ubuntu 16.04, Docker-ce 19.03.12, Kubernetes 1.19.3, weave 2.6.5"
+    mem: 2048
+    name: ubuntu-16.04_k8-1.19_weave-2.6.5
+    revision: 1
+    kind: native
+    sha256_ova: 3c1bec8e2770af5b9b0462e20b7b24633666feedff43c099a6fb1330fcc869a9
+    source_ova: "https://cloud-images.ubuntu.com/releases/xenial/release-20180418/ubuntu-16.04-server-cloudimg-amd64.ova"
+    source_ova_name: ubuntu-16.04-server-cloudimg-amd64.ova
+    os: "ubuntu-16.04"
+    docker_version: "19.03.12"
+    kubernetes: "upstream"
+    kubernetes_version: "1.19.3"
+    cni: "weave"
+    cni_version: "2.6.5"
+    upgrade_from:
+      - "ubuntu-16.04_k8-1.18_weave-2.6.5"
+  -
+    compute_policy: ""
+    cpu: 2
+    deprecated: false
     description: "Ubuntu 16.04, Docker-ce 19.03.12, Kubernetes 1.18.6, weave 2.6.5"
     mem: 2048
     name: ubuntu-16.04_k8-1.18_weave-2.6.5
@@ -43,7 +63,7 @@ templates:
   - 
     compute_policy: ""
     cpu: 2
-    deprecated: false
+    deprecated: true
     description: "Ubuntu 16.04, Docker-ce 18.09.7, Kubernetes 1.16.13, weave 2.6.0"
     mem: 2048
     name: ubuntu-16.04_k8-1.16_weave-2.6.0


### PR DESCRIPTION
- Support for 1.19 Kubernetes template
- Fixed security issues : CVE-2020-8563, CVE-2020-8564, CVE-2020-8566
- Tested the following:
     ` template install`
      `cluster creation using k8s 1.19`
      `cluster upgrade plan`
      `cluster upgrade to k8s 1.19`
----------------------------
 
<img width="802"  src="https://user-images.githubusercontent.com/5530442/96613443-d4965500-12b3-11eb-999e-467dd0b428e2.png">

<img width="827"  src="https://user-images.githubusercontent.com/5530442/96613493-e1b34400-12b3-11eb-8dd8-1b98ca686a69.png">

<img width="833" src="https://user-images.githubusercontent.com/5530442/96613579-fabbf500-12b3-11eb-8217-b2b75cd3bb66.png">

<img width="752" src="https://user-images.githubusercontent.com/5530442/96613636-0c050180-12b4-11eb-91e1-15ff3459a352.png">

<img width="738" alt="Screen Shot 2020-10-20 at 9 18 08 AM" src="https://user-images.githubusercontent.com/5530442/96614660-3c00d480-12b5-11eb-8c6f-b6099e17e6a9.png">

------------------------------------------------
@rocknes @Anirudh9794

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension-templates/18)
<!-- Reviewable:end -->
