### PR TITLE
Fix to change repository from bintray to packages.vmware.com

### DIFF
--- a/scripts/photon-v2_k8-1.12_weave-2.3.0_rev1/cust.sh
+++ b/scripts/photon-v2_k8-1.12_weave-2.3.0_rev1/cust.sh
@@ -21,6 +21,11 @@ chmod 0644 /etc/systemd/system/iptables-ports.service
 systemctl enable iptables-ports.service
 systemctl start iptables-ports.service
 
+# update public repository to point to packages.vmware.com
+pushd /etc/yum.repos.d
+sed -i 's/dl.bintray.com\/vmware/packages.vmware.com\/photon\/$releasever/g' photon.repo photon-updates.repo photon-extras.repo photon-debuginfo.repo
+popd
+
 # update repo info (needed for docker update)
 tdnf makecache -q
 

--- a/scripts/photon-v2_k8-1.12_weave-2.3.0_rev2/cust.sh
+++ b/scripts/photon-v2_k8-1.12_weave-2.3.0_rev2/cust.sh
@@ -21,6 +21,11 @@ chmod 0644 /etc/systemd/system/iptables-ports.service
 systemctl enable iptables-ports.service
 systemctl start iptables-ports.service
 
+# update public repository to point to packages.vmware.com
+pushd /etc/yum.repos.d
+sed -i 's/dl.bintray.com\/vmware/packages.vmware.com\/photon\/$releasever/g' photon.repo photon-updates.repo photon-extras.repo photon-debuginfo.repo
+popd
+
 # update repo info (needed for docker update)
 tdnf makecache -q
 

--- a/scripts/photon-v2_k8-1.14_weave-2.5.2_rev1/cust.sh
+++ b/scripts/photon-v2_k8-1.14_weave-2.5.2_rev1/cust.sh
@@ -21,6 +21,11 @@ chmod 0644 /etc/systemd/system/iptables-ports.service
 systemctl enable iptables-ports.service
 systemctl start iptables-ports.service
 
+# update public repository to point to packages.vmware.com
+pushd /etc/yum.repos.d
+sed -i 's/dl.bintray.com\/vmware/packages.vmware.com\/photon\/$releasever/g' photon.repo photon-updates.repo photon-extras.repo photon-debuginfo.repo
+popd
+
 # update repo info (needed for docker update)
 tdnf makecache -q
 

--- a/scripts/photon-v2_k8-1.14_weave-2.5.2_rev2/cust.sh
+++ b/scripts/photon-v2_k8-1.14_weave-2.5.2_rev2/cust.sh
@@ -21,6 +21,11 @@ chmod 0644 /etc/systemd/system/iptables-ports.service
 systemctl enable iptables-ports.service
 systemctl start iptables-ports.service
 
+# update public repository to point to packages.vmware.com
+pushd /etc/yum.repos.d
+sed -i 's/dl.bintray.com\/vmware/packages.vmware.com\/photon\/$releasever/g' photon.repo photon-updates.repo photon-extras.repo photon-debuginfo.repo
+popd
+
 # update repo info (needed for docker update)
 tdnf makecache -q
 tdnf update tdnf -y

--- a/scripts/photon-v2_k8-1.14_weave-2.5.2_rev3/cust.sh
+++ b/scripts/photon-v2_k8-1.14_weave-2.5.2_rev3/cust.sh
@@ -21,6 +21,11 @@ chmod 0644 /etc/systemd/system/iptables-ports.service
 systemctl enable iptables-ports.service
 systemctl start iptables-ports.service
 
+# update public repository to point to packages.vmware.com
+pushd /etc/yum.repos.d
+sed -i 's/dl.bintray.com\/vmware/packages.vmware.com\/photon\/$releasever/g' photon.repo photon-updates.repo photon-extras.repo photon-debuginfo.repo
+popd
+
 # update repo info (needed for docker update)
 tdnf makecache -q
 tdnf update tdnf -y


### PR DESCRIPTION
Change photon public repository from bintray to packages.vmware.com

Testing done:
Created a photon template successfully

Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension-templates/19)
<!-- Reviewable:end -->
