### PR TITLE
[VCDA-1881] maintain most recent k8 three minor releases for ubuntu

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -43,7 +43,7 @@ templates:
   - 
     compute_policy: ""
     cpu: 2
-    deprecated: false
+    deprecated: true
     description: "Ubuntu 16.04, Docker-ce 18.09.7, Kubernetes 1.16.13, weave 2.6.0"
     mem: 2048
     name: ubuntu-16.04_k8-1.16_weave-2.6.0
@@ -61,26 +61,6 @@ templates:
     upgrade_from:
       - "ubuntu-16.04_k8-1.15_weave-2.5.2"
       - "ubuntu-16.04_k8-1.16_weave-2.6.0"
-  - 
-    compute_policy: ""
-    cpu: 2
-    deprecated: true
-    description: "Ubuntu 16.04, Docker-ce 18.09.7, Kubernetes 1.15.12, weave 2.5.2"
-    mem: 2048
-    name: ubuntu-16.04_k8-1.15_weave-2.5.2
-    revision: 4
-    kind: native
-    sha256_ova: 3c1bec8e2770af5b9b0462e20b7b24633666feedff43c099a6fb1330fcc869a9
-    source_ova: "https://cloud-images.ubuntu.com/releases/xenial/release-20180418/ubuntu-16.04-server-cloudimg-amd64.ova"
-    source_ova_name: ubuntu-16.04-server-cloudimg-amd64.ova
-    os: "ubuntu-16.04"
-    docker_version: "18.09.7"
-    kubernetes: "upstream"
-    kubernetes_version: "1.15.12"
-    cni: "weave"
-    cni_version: "2.5.2"
-    upgrade_from:
-      - "ubuntu-16.04_k8-1.15_weave-2.5.2"
   - 
     compute_policy: ""
     cpu: 2


### PR DESCRIPTION
- Keep k8 three minor releases 
- https://kubernetes.io/docs/setup/release/version-skew-policy/: The Kubernetes project maintains release branches for the most recent three minor releases (1.19, 1.18, 1.17).
- Based on the above documentation on version support policy, 1.16 gets decpreated. ubuntu-16.04_k8-1.15 removed from template.yaml

@Anirudh9794 @rocknes @andrew-ni

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension-templates/21)
<!-- Reviewable:end -->
