### PR TITLE
[VCDA-5294] Native-Cluster-Creation-Fix-Due-To-Old-Containerd

### DIFF
--- a/scripts_v2/ubuntu-20.04_k8-1.23_weave-2.8.1_rev1/cust.sh
+++ b/scripts_v2/ubuntu-20.04_k8-1.23_weave-2.8.1_rev1/cust.sh
@@ -31,7 +31,7 @@ while [ `systemctl is-active systemd-networkd` != 'active' ]; do echo 'waiting f
 echo 'installing kubernetes'
 
 docker_ce_version=5:20.10.12~3-0~ubuntu-focal
-containerd_version=1.4.12-1
+containerd_version=1.6.18-1
 kubernetes_tools_version=1.23.3-00
 kubernetes_cni_version=0.8.7-00
 weave_version=2.8.1

--- a/template_v2.yaml
+++ b/template_v2.yaml
@@ -3,7 +3,7 @@ scripts_directory: scripts_v2
 templates:
   - cpu: 2
     deprecated: false
-    description: "Ubuntu 20.04, Docker-ce 20.10.12, Kubernetes 1.23.3, weave 2.8.1, containerd 1.4.12"
+    description: "Ubuntu 20.04, Docker-ce 20.10.12, Kubernetes 1.23.3, weave 2.8.1, containerd 1.6.18"
     mem: 2048
     name: ubuntu-20.04_k8-1.23_weave-2.8.1
     revision: 1


### PR DESCRIPTION
- This fixes failing Native cluster creation that used Ubuntu-20 k8s 1.23  with old containerd 1.14 that reached end of life 
- Updated the containerd.io for template customization
- Ref: https://github.com/containerd/containerd/blob/main/RELEASES.md
- Tested cluster creation  

`Could not initialize cluster: Initialize cluster script execution failed on node ['mstr-4mb3']:['error execution phase preflight: [preflight] Some fatal errors occurred:\n\t[ERROR CRI]: container runtime is not running: output: time="2023-02-21T11:47:55Z" level=fatal msg="validate service connection: ubuntu-20.04_k8-1.23_weave-2.8.1 \\"unix:///run/containerd/containerd.sock
": rpc error: code = Unimplemented desc = unknown service runtime.v1.RuntimeService"\n, error: exit status 1\n[preflight] If you know what you are doing, you can make a check non-fatal with `--ignore-preflight-errors=...`\nTo see the stack trace of this error execute with --v=5 or higher\n']`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/container-service-extension-templates/68)
<!-- Reviewable:end -->
